### PR TITLE
Fix local building

### DIFF
--- a/org.videolan.VLC.Plugin.pause_click.json
+++ b/org.videolan.VLC.Plugin.pause_click.json
@@ -18,7 +18,7 @@
       "buildsystem": "simple",
       "build-options": {
         "env": {
-          "MAKEFLAGS": "-j $FLATPAK_BUILDER_N_JOBS"
+          "MAKEFLAGS": "-j ${FLATPAK_BUILDER_N_JOBS}"
         }
       },
       "build-commands": [


### PR DESCRIPTION
Somehow it kept failing to build for me locally with:

    make: *** No rule to make target 'LATPAK_BUILDER_N_JOBS'.  Stop.

It builds just fine on Flathub and it built fine on my machine 9 months ago too.

This change fixes the local building for me.