### PR TITLE
Don't build VLC

### DIFF
--- a/org.videolan.VLC.Plugin.pause_click.json
+++ b/org.videolan.VLC.Plugin.pause_click.json
@@ -14,34 +14,8 @@
   },
   "modules": [
     {
-      "name": "vlc-sdk",
-      "buildsystem": "simple",
-      "build-options": {
-        "env": {
-          "MAKEFLAGS": "-j ${FLATPAK_BUILDER_N_JOBS}"
-        }
-      },
-      "build-commands": [
-        "./configure BUILDCC=/usr/bin/gcc --prefix=/var/tmp/vlc-sdk --disable-lua --disable-vlm --disable-addonmanagermodules --disable-archive --disable-live555 --disable-dc1394 --disable-dv1394 --disable-linsys --disable-dvdread --disable-dvdnav --disable-bluray --disable-opencv --disable-smbclient --disable-dsm --disable-sftp --disable-nfs --disable-v4l2 --disable-decklink --disable-vcd --disable-libcddb --disable-screen --disable-vnc --disable-freerdp --disable-realrtsp --disable-macosx-qtkit --disable-macosx-avfoundation --disable-asdcp --disable-dvbpsi --disable-gme --disable-sid --disable-ogg --disable-shout --disable-matroska --disable-mod --disable-mpc --disable-wma-fixed --disable-shine --disable-omxil --disable-omxil-vout --disable-rpi-omxil --disable-crystalhd --disable-mad --disable-mpg123 --disable-gst-decode --disable-merge-ffmpeg --disable-avcodec --disable-libva --disable-dxva2 --disable-d3d11va --disable-avformat --disable-swscale --disable-postproc --disable-faad --disable-aom --disable-vpx --disable-twolame --disable-fdkaac --disable-a52 --disable-dca --disable-flac --disable-libmpeg2 --disable-vorbis --disable-tremor --disable-speex --disable-opus --disable-spatialaudio --disable-theora --disable-oggspots --disable-daala --disable-schroedinger --disable-png --disable-jpeg --disable-bpg --disable-x262 --disable-x265 --disable-x26410b --disable-x264 --disable-mfx --disable-fluidsynth --disable-fluidlite --disable-zvbi --disable-telx --disable-libass --disable-aribsub --disable-aribb25 --disable-kate --disable-tiger --disable-css --disable-gles2 --disable-xcb --disable-xvideo --disable-vdpau --disable-wayland --disable-sdl-image --disable-freetype --disable-fribidi --disable-harfbuzz --disable-fontconfig --disable-svg --disable-svgdec --disable-directx --disable-aa --disable-caca --disable-kva --disable-mmal --disable-evas --disable-pulse --disable-alsa --disable-oss --disable-sndio --disable-wasapi --disable-jack --disable-opensles --disable-tizen-audio --disable-samplerate --disable-soxr --disable-kai --disable-chromaprint --disable-chromecast --disable-qt --disable-skins2 --disable-libtar --disable-macosx --disable-sparkle --disable-minimal-macosx --disable-ncurses --disable-lirc --disable-srt --disable-goom --disable-projectm --disable-vsxu --disable-avahi --disable-udev --disable-mtp --disable-upnp --disable-microdns --disable-libxml2 --disable-libgcrypt --disable-gnutls --disable-taglib --disable-secret --disable-kwallet --disable-update-check --disable-osx-notifications --disable-notify --disable-libplacebo --disable-vlc",
-        "make libcompat",
-        "make -C src all",
-        "make install -C src",
-        "make -C lib install-data"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://download.videolan.org/pub/videolan/vlc/3.0.0/vlc-3.0.0.tar.xz",
-          "sha256": "68d587999f50d58df5ca3d69998bba910bdb5a82e5a1a39247179932fae0c19c"
-        }
-      ]
-    },
-    {
       "name": "vlc-pause-click-plugin",
       "buildsystem": "simple",
-      "build-options": {
-        "append-pkg-config-path": "/var/tmp/vlc-sdk/lib/pkgconfig"
-      },
       "build-commands": [
         "make"
       ],


### PR DESCRIPTION
We used to build ABI-compatible minimal VLC solely for the VLC headers needed to build the plugin, but org.videolan.VLC.Plugin has started providing the headers in its runtime, so we no longer need to use this workaround.

https://github.com/flathub/org.videolan.VLC.Plugin.makemkv/pull/14#issuecomment-1782077928
https://github.com/flathub/org.videolan.VLC/pull/187
org.videolan.VLC 86666d391776563024a7fe0dbc178888435ce20d