### PR TITLE
Replace the appstream-compose call with an appstreamcli call

### DIFF
--- a/org.videolan.VLC.Plugin.pause_click.json
+++ b/org.videolan.VLC.Plugin.pause_click.json
@@ -23,7 +23,7 @@
         "install -Dp -m 644 libpause_click_plugin.so --target-directory=${FLATPAK_DEST}/plugins",
         "install -Dp -m 644 org.videolan.VLC.Plugin.pause_click.appdata.xml --target-directory=${FLATPAK_DEST}/share/metainfo",
         "install -Dp -m 755 usage.sh --target-directory=${FLATPAK_DEST}",
-        "appstream-compose --basename=org.videolan.VLC.Plugin.pause_click --prefix=${FLATPAK_DEST} --origin=flatpak org.videolan.VLC.Plugin.pause_click"
+        "appstreamcli compose --components=${FLATPAK_ID} --prefix=/ --origin=${FLATPAK_ID} --result-root=${FLATPAK_DEST} --data-dir=${FLATPAK_DEST}/share/app-info/xmls ${FLATPAK_DEST}"
       ],
       "sources": [
         {


### PR DESCRIPTION
As, suposedly, appstream-compose will not be present in the upcoming Freedesktop SDK 24.08.

Fixes #5